### PR TITLE
Enable case class (instance of Product) handling

### DIFF
--- a/src/main/scala/com/sfxcode/templating/pebble/extension/ScalaResolver.scala
+++ b/src/main/scala/com/sfxcode/templating/pebble/extension/ScalaResolver.scala
@@ -23,9 +23,9 @@ case class ScalaResolver() extends AttributeResolver {
         new ResolvedAttribute(it.toList(attributeNameValue.toString.toInt))
       case option: Option[_] if option.isDefined =>
         new ResolvedAttribute(option.get)
-      case anyObj: Any if anyObj.isInstanceOf[Product] =>
-        val declaredFieldsNames = anyObj.getClass.getDeclaredFields.map(_.getName)
-        val productSeq          = anyObj.asInstanceOf[Product].productIterator.toSeq
+      case p: Product =>
+        val declaredFieldsNames = p.getClass.getDeclaredFields.map(_.getName)
+        val productSeq          = p.asInstanceOf[Product].productIterator.toSeq
         val map                 = declaredFieldsNames.zip(productSeq).toMap
         resolve(map, attributeNameValue, argumentValues, args, context, filename, lineNumber)
       case _ => null

--- a/src/main/scala/com/sfxcode/templating/pebble/extension/ScalaResolver.scala
+++ b/src/main/scala/com/sfxcode/templating/pebble/extension/ScalaResolver.scala
@@ -6,23 +6,25 @@ import com.mitchellbosecke.pebble.template.EvaluationContextImpl
 
 case class ScalaResolver() extends AttributeResolver {
   override def resolve(
-      obj: Any,
-      attributeNameValue: Any,
-      argumentValues: Array[AnyRef],
-      args: ArgumentsNode,
-      context: EvaluationContextImpl,
-      filename: String,
-      lineNumber: Int
-  ): ResolvedAttribute =
+                        obj: Any,
+                        attributeNameValue: Any,
+                        argumentValues: Array[AnyRef],
+                        args: ArgumentsNode,
+                        context: EvaluationContextImpl,
+                        filename: String,
+                        lineNumber: Int
+                      ): ResolvedAttribute =
     obj match {
 
       case map: collection.Map[String, _] if map.keySet.contains(attributeNameValue.toString) =>
         new ResolvedAttribute(map(attributeNameValue.toString))
       case it: collection.Iterable[_]
-          if !it.isInstanceOf[Map[String, Any]] && it.size > attributeNameValue.toString.toInt =>
+        if !it.isInstanceOf[Map[String, Any]] && it.size > attributeNameValue.toString.toInt =>
         new ResolvedAttribute(it.toList(attributeNameValue.toString.toInt))
       case option: Option[_] if option.isDefined =>
         new ResolvedAttribute(option.get)
+      case anyObj: Any if anyObj.isInstanceOf[Product] =>
+        new ResolvedAttribute(anyObj.getClass.getDeclaredFields.map(_.getName).zip(anyObj.asInstanceOf[Product].productIterator.toSeq).toMap)
       case _ => null
     }
 

--- a/src/main/scala/com/sfxcode/templating/pebble/extension/ScalaResolver.scala
+++ b/src/main/scala/com/sfxcode/templating/pebble/extension/ScalaResolver.scala
@@ -24,7 +24,10 @@ case class ScalaResolver() extends AttributeResolver {
       case option: Option[_] if option.isDefined =>
         new ResolvedAttribute(option.get)
       case anyObj: Any if anyObj.isInstanceOf[Product] =>
-        new ResolvedAttribute(anyObj.getClass.getDeclaredFields.map(_.getName).zip(anyObj.asInstanceOf[Product].productIterator.toSeq).toMap)
+        val declaredFieldsNames = anyObj.getClass.getDeclaredFields.map(_.getName)
+        val productSeq          = anyObj.asInstanceOf[Product].productIterator.toSeq
+        val map                 = declaredFieldsNames.zip(productSeq).toMap
+        resolve(map, attributeNameValue, argumentValues, args, context, filename, lineNumber)
       case _ => null
     }
 

--- a/src/test/resources/templates/engine/basic_injection.peb
+++ b/src/test/resources/templates/engine/basic_injection.peb
@@ -2,6 +2,6 @@
 <head>
 </head>
 <body>
-{{ data.getDataObjectValue('impressions') }}
+{{ data.aDescriptionString }}
 </body>
 </html>

--- a/src/test/resources/templates/engine/basic_injection.peb
+++ b/src/test/resources/templates/engine/basic_injection.peb
@@ -1,7 +1,10 @@
 <html>
 <head>
+    <title>{{ data.aDescriptionString }}</title>
 </head>
 <body>
-{{ data.aDescriptionString }}
+<h1>{{ tuple._1 }}</h1>
+<p>{{ tuple._2 }}</p>
+<p>{{ tuple._3 }} - {{ tuple._4 }}</p>
 </body>
 </html>

--- a/src/test/resources/templates/engine/basic_injection.peb
+++ b/src/test/resources/templates/engine/basic_injection.peb
@@ -1,0 +1,7 @@
+<html>
+<head>
+</head>
+<body>
+{{ data.getDataObjectValue('impressions') }}
+</body>
+</html>

--- a/src/test/scala/com/sfxcode/templating/pebble/PebbleEngineSpec.scala
+++ b/src/test/scala/com/sfxcode/templating/pebble/PebbleEngineSpec.scala
@@ -15,7 +15,7 @@ class PebbleEngineSpec extends Specification {
       evaluated must contain("<li>Element1</li>")
     }
 
-    "evaluate template from string and case class from context" in {
+    "evaluate template from string and case class and tuple from context" in {
 
       val someBigLongValue   : Long   = 99999L
       val otherLongValue     : Long   = 6666L
@@ -23,9 +23,13 @@ class PebbleEngineSpec extends Specification {
       val aDescriptionString : String = "This is a simple string"
 
       val data = TestCaseClass(someBigLongValue, otherLongValue, niceDoubleValue, aDescriptionString)
-      val context = Map("data" -> data)
+      val tuple = ("Wisdom is the daughter of experience", "Leonardo da Vinci", 1452, 1519)
+      val context = Map("data" -> data, "tuple" -> tuple)
       val evaluated = Engine.evaluateToString("templates/engine/basic_injection.peb", context)
       evaluated must contain("This is a simple string")
+      evaluated must contain("1452 - 1519")
+      evaluated must contain("Wisdom is the daughter of experience")
+      evaluated must contain("Leonardo da Vinci")
     }
 
   }

--- a/src/test/scala/com/sfxcode/templating/pebble/PebbleEngineSpec.scala
+++ b/src/test/scala/com/sfxcode/templating/pebble/PebbleEngineSpec.scala
@@ -14,6 +14,31 @@ class PebbleEngineSpec extends Specification {
       evaluated must contain("<title>pebble-scala</title>")
       evaluated must contain("<li>Element1</li>")
     }
+
+    "evaluate template from string and case class from context" in {
+
+      val someBigLongValue   : Long   = 99999L
+      val otherLongValue     : Long   = 6666L
+      val niceDoubleValue    : Double =  25.25
+      val aDescriptionString : String = "Das ist ein einfacher String"
+
+      val data = TestCaseClass(someBigLongValue, otherLongValue, niceDoubleValue, aDescriptionString)
+      val context = Map("data" -> data)
+      val evaluated = Engine.evaluateToString("templates/engine/basic_injection.peb", context)
+      evaluated must contain("Das ist ein einfacher String")
+    }
+
   }
 
 }
+
+/**
+ * Simple Helper Case Class for Testing injection of case classes into pebble templates
+ * The implementation is not main part of test case
+ *
+ * @param someBigLongValue - just a long value
+ * @param otherLongValue - just another long value
+ * @param niceDoubleValue - just a double value
+ * @param aDescriptionString - just a String value
+ */
+case class TestCaseClass(someBigLongValue: Long, otherLongValue: Long, niceDoubleValue: Double, aDescriptionString: String)

--- a/src/test/scala/com/sfxcode/templating/pebble/PebbleEngineSpec.scala
+++ b/src/test/scala/com/sfxcode/templating/pebble/PebbleEngineSpec.scala
@@ -20,12 +20,12 @@ class PebbleEngineSpec extends Specification {
       val someBigLongValue   : Long   = 99999L
       val otherLongValue     : Long   = 6666L
       val niceDoubleValue    : Double =  25.25
-      val aDescriptionString : String = "Das ist ein einfacher String"
+      val aDescriptionString : String = "This is a simple string"
 
       val data = TestCaseClass(someBigLongValue, otherLongValue, niceDoubleValue, aDescriptionString)
       val context = Map("data" -> data)
       val evaluated = Engine.evaluateToString("templates/engine/basic_injection.peb", context)
-      evaluated must contain("Das ist ein einfacher String")
+      evaluated must contain("This is a simple string")
     }
 
   }

--- a/src/test/scala/com/sfxcode/templating/pebble/engine/extension/ScalaResolverSpec.scala
+++ b/src/test/scala/com/sfxcode/templating/pebble/engine/extension/ScalaResolverSpec.scala
@@ -57,6 +57,23 @@ class ScalaResolverSpec extends Specification {
       Engine.evaluateToString("{{ bi }}", Map("bi" -> BigInt(42))) mustEqual "42"
       Engine.evaluateToString("{{ bd }}", Map("bd" -> BigDecimal(42.5))) mustEqual "42.5"
     }
+    
+    "evaluate scala case class in" in {
+
+      case class Foo(bar: String)
+      val result = Engine.evaluateToString("{{ caseClass.bar }}", Map("caseClass" -> Foo("FooBar")))
+      result mustEqual "FooBar"
+    }
+
+    "evaluate scala class in" in {
+
+      class Foo(val bar: String) {
+        def getFooBarString = s"Foo is $bar"
+      }
+      
+      val result = Engine.evaluateToString("{{ Class.getFooBarString }}", Map("Class" -> new Foo("FooBar")))
+      result mustEqual "Foo is FooBar"
+    }
   }
 
 }

--- a/src/test/scala/com/sfxcode/templating/pebble/engine/extension/ScalaResolverSpec.scala
+++ b/src/test/scala/com/sfxcode/templating/pebble/engine/extension/ScalaResolverSpec.scala
@@ -74,6 +74,14 @@ class ScalaResolverSpec extends Specification {
       val result = Engine.evaluateToString("{{ Class.getFooBarString }}", Map("Class" -> new Foo("FooBar")))
       result mustEqual "Foo is FooBar"
     }
+
+    "evaluate scala tuple in" in {
+
+      val fooBar: (String, Int, Double) = ("Test String", 1, 3.14)
+      val result = Engine.evaluateToString("{{ fooBar._1 }}: {{ fooBar._2 }}", Map("fooBar" -> fooBar))
+      result mustEqual "Test String: 1"
+    }
+
   }
 
 }


### PR DESCRIPTION
Hi Tom,

here you can find a little patch to improve your pebble-scala framework. These changes allows to apply case classes to context for evaluating by pebble engine. As result you can access attributes of case classes inside of templates.

best regards
Martin