### PR TITLE
Update Scala cross build to 3.3.0 LTS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "pebble-scala"
 
-crossScalaVersions := Seq("3.1.0", "2.13.11", "2.12.18")
+crossScalaVersions := Seq("3.3.0", "2.13.11", "2.12.18")
 
 scalaVersion := crossScalaVersions.value.head
 


### PR DESCRIPTION
The LTS Version of Scala 3 has been released. I think it would be a good idea to use this instead of 3.1.0.