### PR TITLE
Scala contains expression

### DIFF
--- a/src/main/scala/com/sfxcode/templating/pebble/ScalaPebbleEngine.scala
+++ b/src/main/scala/com/sfxcode/templating/pebble/ScalaPebbleEngine.scala
@@ -11,12 +11,22 @@ import com.sfxcode.templating.pebble.extension.ScalaExtension
 
 import scala.jdk.CollectionConverters._
 
-case class ScalaPebbleEngine(useStringLoader: Boolean = false, globalContext: Map[String, AnyRef] = Map()) {
+class ScalaPebbleEngine(useStringLoader: Boolean = false, globalContext: Map[String, AnyRef] = Map()) {
 
   private val PebbleBuilder             = new PebbleEngine.Builder()
   private var engine: Option[PebbleEngine] = None
 
-  var scalaExtension: ScalaExtension = new ScalaExtension(globalContext)
+  PebbleBuilder
+    .extension(getExtension)
+    .allowOverrideCoreOperators(true)
+
+  if (useStringLoader) {
+    PebbleBuilder.loader(new StringLoader())
+  }
+
+  def getExtension: Extension =
+    new ScalaExtension(globalContext)
+
   def getBuilder: PebbleEngine.Builder = {
     if (engine.isDefined)
       throw new IllegalAccessError("access ot builder after engine initialization is not permitted")
@@ -25,10 +35,7 @@ case class ScalaPebbleEngine(useStringLoader: Boolean = false, globalContext: Ma
 
   def getEngine: PebbleEngine = {
     if (engine.isEmpty) {
-      PebbleBuilder.extension(scalaExtension)
-      if (useStringLoader)
-        getBuilder.loader(new StringLoader())
-      engine = Some(PebbleBuilder.build())
+      engine = Some(getBuilder.build())
     }
     engine.get
   }

--- a/src/main/scala/com/sfxcode/templating/pebble/ScalaPebbleEngine.scala
+++ b/src/main/scala/com/sfxcode/templating/pebble/ScalaPebbleEngine.scala
@@ -11,7 +11,7 @@ import com.sfxcode.templating.pebble.extension.ScalaExtension
 
 import scala.jdk.CollectionConverters._
 
-class ScalaPebbleEngine(useStringLoader: Boolean = false, globalContext: Map[String, AnyRef] = Map()) {
+class ScalaPebbleEngine(useStringLoader: Boolean, globalContext: Map[String, AnyRef]) {
 
   private val PebbleBuilder             = new PebbleEngine.Builder()
   private var engine: Option[PebbleEngine] = None
@@ -63,4 +63,9 @@ class ScalaPebbleEngine(useStringLoader: Boolean = false, globalContext: Map[Str
     writer
   }
 
+}
+
+object ScalaPebbleEngine {
+  def apply(useStringLoader: Boolean = false, globalContext: Map[String, AnyRef] = Map()) =
+    new ScalaPebbleEngine(useStringLoader, globalContext)
 }

--- a/src/main/scala/com/sfxcode/templating/pebble/extension/ScalaExtension.scala
+++ b/src/main/scala/com/sfxcode/templating/pebble/extension/ScalaExtension.scala
@@ -6,8 +6,10 @@ import io.pebbletemplates.pebble.attributes.AttributeResolver
 import scala.jdk.CollectionConverters._
 import io.pebbletemplates.pebble.extension.{AbstractExtension, Test}
 import io.pebbletemplates.pebble.tokenParser.TokenParser
+import com.sfxcode.templating.pebble.extension.node.expression._
 import com.sfxcode.templating.pebble.extension.test._
 import com.sfxcode.templating.pebble.extension.tokenParser.{DoTokenParser, ForTokenParser}
+import io.pebbletemplates.pebble.operator.{Associativity, BinaryOperator, BinaryOperatorImpl, BinaryOperatorType}
 
 class ScalaExtension(globalContext: Map[String, AnyRef] = Map()) extends AbstractExtension {
 
@@ -25,4 +27,9 @@ class ScalaExtension(globalContext: Map[String, AnyRef] = Map()) extends Abstrac
 
   override def getTokenParsers: util.List[TokenParser] =
     List[TokenParser](ForTokenParser(), DoTokenParser()).asJava
+
+  override def getBinaryOperators: util.List[BinaryOperator] =
+    List[BinaryOperator](
+      new BinaryOperatorImpl("contains", 20, () => new ScalaContainsExpression(), BinaryOperatorType.NORMAL, Associativity.LEFT)
+    ).asJava
 }

--- a/src/main/scala/com/sfxcode/templating/pebble/extension/node/expression/ScalaContainsExpression.scala
+++ b/src/main/scala/com/sfxcode/templating/pebble/extension/node/expression/ScalaContainsExpression.scala
@@ -1,5 +1,6 @@
 package com.sfxcode.templating.pebble.extension.node.expression
 
+import com.sfxcode.templating.pebble.compat._
 import io.pebbletemplates.pebble.node.expression.ContainsExpression
 import io.pebbletemplates.pebble.template.{EvaluationContextImpl, PebbleTemplateImpl}
 

--- a/src/main/scala/com/sfxcode/templating/pebble/extension/node/expression/ScalaContainsExpression.scala
+++ b/src/main/scala/com/sfxcode/templating/pebble/extension/node/expression/ScalaContainsExpression.scala
@@ -1,0 +1,45 @@
+package com.sfxcode.templating.pebble.extension.node.expression
+
+import io.pebbletemplates.pebble.node.expression.ContainsExpression
+import io.pebbletemplates.pebble.template.{EvaluationContextImpl, PebbleTemplateImpl}
+
+import java.{lang, util}
+import scala.jdk.CollectionConverters._
+
+class ScalaContainsExpression extends ContainsExpression {
+  override def evaluate(self: PebbleTemplateImpl, context: EvaluationContextImpl): lang.Boolean = {
+    val leftValue = getLeftExpression.evaluate(self, context)
+    if (leftValue == null) {
+      return false
+    }
+
+    val rightValue = getRightExpression.evaluate(self, context)
+
+    val (left, leftIsSeq) = leftValue match {
+      case map: collection.Map[_, _] => (map.keys.toSeq, false)
+      case map: util.Map[_, _]       => (map.keySet().asScala.toSeq, false)
+      case seq: collection.Seq[_]    => (seq, true)
+      case it: IterableOnce[_]       => (it.iterator.toSeq, true)
+      case col: util.Collection[_]   => (col.asScala.toSeq, true)
+      case xs                        => (xs, false)
+    }
+
+    val right = if (leftIsSeq) {
+      rightValue match {
+        case seq: collection.Seq[_]  => seq
+        case it: IterableOnce[_]     => it.iterator.toSeq
+        case col: util.Collection[_] => col.asScala.toSeq
+        case xs                      => xs
+      }
+    } else {
+      rightValue
+    }
+
+    (leftIsSeq, left, right) match {
+      case (true, l: collection.Seq[_], r: collection.Seq[_]) => r.forall { l.contains }
+      case (true, l: collection.Seq[_], r)                    => l.contains(r)
+      case (false, l: collection.Seq[_], r)                   => l.contains(r)
+      case _                                                  => super.evaluate(self, context)
+    }
+  }
+}

--- a/src/test/scala/com/sfxcode/templating/pebble/engine/extension/ExpressionSuite.scala
+++ b/src/test/scala/com/sfxcode/templating/pebble/engine/extension/ExpressionSuite.scala
@@ -1,0 +1,87 @@
+package com.sfxcode.templating.pebble.engine.extension
+
+import com.sfxcode.templating.pebble.ScalaPebbleEngine
+import munit.Location
+
+import java.util
+import scala.collection.mutable
+
+class ExpressionSuite extends munit.FunSuite {
+  val Engine: ScalaPebbleEngine = ScalaPebbleEngine(useStringLoader = true)
+
+  case class Data[T](x: T)
+
+  private def assertContains[A <: AnyRef, B <: AnyRef](left: A, right: B)(implicit loc: Location) =
+    assertEquals(Engine.evaluateToString("{% if left contains right %}yes{% endif %}", Map("left" -> left, "right" -> right)), "yes")
+
+  private def assertNotContains[A <: AnyRef, B <: AnyRef](left: A, right: B)(implicit loc: Location) =
+    assertNotEquals(Engine.evaluateToString("{% if left contains right %}yes{% endif %}", Map("left" -> left, "right" -> right)), "yes")
+
+  test("simple collection contains expression") {
+    assertContains(List(1, 2, 3), 2)
+    assertNotContains(List(1, 2, 3), 4)
+    assertNotContains(List(1, 2, 3), "2")
+
+    assertContains(mutable.Set(1, 2, 3), 2)
+    assertNotContains(mutable.Set(1, 2, 3), 4)
+    assertNotContains(mutable.Set(1, 2, 3), "2")
+
+    assertContains(util.List.of(1, 2, 3), 2)
+    assertNotContains(util.List.of(1, 2, 3), 4)
+    assertNotContains(util.List.of(1, 2, 3), "2")
+
+    assertContains(List(Data("a")), Data("a"))
+    assertNotContains(List(Data("a")), Data(1))
+
+    // tuples are sub-classes of Product and are treated like other non-collections
+    assertContains(List("a" -> 1, "b" -> 2), "a" -> 1)
+    assertNotContains(List("a" -> 1, "b" -> 2), "a" -> 2)
+  }
+
+  test("collection contains collection expression") {
+    assertContains(List(1, 2, 3), List(2))
+    assertContains(List(1, 2, 3), List(1, 3))
+    assertNotContains(List(1, 2, 3), List(1, 4))
+
+    assertContains(List(1, 2, 3), mutable.Set(2))
+    assertContains(List(1, 2, 3), mutable.Set(1, 3))
+    assertNotContains(List(1, 2, 3), mutable.Set(1, 4))
+
+    assertContains(util.List.of(1, 2, 3), Set(2))
+    assertContains(util.List.of(1, 2, 3), Set(1, 3))
+    assertNotContains(util.List.of(1, 2, 3), Set(1, 4))
+
+    assertContains(List(1, 2, 3), util.List.of(2))
+    assertContains(List(1, 2, 3), util.List.of(1, 3))
+    assertNotContains(List(1, 2, 3), util.List.of(1, 4))
+
+    assertContains(util.List.of(1, 2, 3), util.List.of(2))
+    assertContains(util.List.of(1, 2, 3), util.List.of(1, 3))
+    assertNotContains(util.List.of(1, 2, 3), util.List.of(1, 4))
+  }
+
+  test("simple map contains expression") {
+    assertContains(Map(1 -> "a", 2 -> "b", 3 -> "c"), 2)
+    assertNotContains(Map(1 -> "a", 2 -> "b", 3 -> "c"), 4)
+    assertNotContains(Map(1 -> "a", 2 -> "b", 3 -> "c"), "2")
+
+    assertContains(util.Map.of(1, "a", 2 , "b", 3, "c"), 2)
+    assertNotContains(util.Map.of(1, "a", 2 , "b", 3, "c"), 4)
+    assertNotContains(util.Map.of(1, "a", 2 , "b", 3, "c"), "2")
+
+    // "contains all"-type comparisons between map and list are not supported by pebble's own "contains"
+    assertNotContains(Map(1 -> "a", 2 -> "b", 3 -> "c"), List(2))
+  }
+
+  test("evaluated contains expressions") {
+    assertEquals(Engine.evaluateToString("{% if a contains 1 %}yes{% endif %}", Map("a" -> List(1))), "yes")
+    assertNotEquals(Engine.evaluateToString("{% if a contains 2 %}yes{% endif %}", Map("a" -> List(1))), "yes")
+
+    assertEquals(Engine.evaluateToString("{% if [1, 2] contains a %}yes{% endif %}", Map("a" -> List(1))), "yes")
+    assertEquals(Engine.evaluateToString("{% if [1, 2] contains a %}yes{% endif %}", Map("a" -> List(1, 2))), "yes")
+    assertNotEquals(Engine.evaluateToString("{% if [1, 2] contains a %}yes{% endif %}", Map("a" -> List(3))), "yes")
+
+    assertEquals(Engine.evaluateToString("""{% if {"a": 1} contains a %}yes{% endif %}""", Map("a" -> "a")), "yes")
+    assertNotEquals(Engine.evaluateToString("""{% if {"a": 1} contains a %}yes{% endif %}""", Map("a" -> 7)), "yes")
+  }
+}


### PR DESCRIPTION
Fixes #41.

I took the liberty to refactor `ScalaPebbleEngine` a bit, turning it into a class but keeping the `ScalaPebbleEngine.apply()` method. One can override the extension by `override def getExtension` and completely override the builder if that is needed by `override def getBuilder`. Otherwise, the default builder gets configured on instantiation. Please feel free to revert this, but remember to add `PebbleBuilder.allowOverrideCoreOperators(true)`.